### PR TITLE
removed Z scaling from HeightMap Exporter

### DIFF
--- a/ArmaToolbox/ASCExporter.py
+++ b/ArmaToolbox/ASCExporter.py
@@ -35,7 +35,7 @@ def exportASC(context, fileName):
     # dump the heightfield. One line contains one row of vertices
     row = rowcols
     for v in obj.data.vertices:
-        filePtr.write("{:.4f}".format(v.co[2] * 100))
+        filePtr.write("{:.4f}".format(v.co[2]))
         row -= 1
         if row == 0:
             filePtr.write("\n")


### PR DESCRIPTION
I don't know why initially the Z values got scaled by 100, but I like to work on my terrain on fullscale in Blender and it took me quite some trial and error to find out I need to scale my Z down by 100.
I consider it more noob friendly without that scaling, because now what you see in blender is what you get in terrain builder. It also allows me to create and fit custom buildings in blender more easily into the terrain.