### PR TITLE
Fix linked objects throwing an error

### DIFF
--- a/ArmaToolbox/MDLexporter.py
+++ b/ArmaToolbox/MDLexporter.py
@@ -589,7 +589,8 @@ def exportObjectListAsMDL(myself, filePtr, applyModifiers, mergeSameLOD, objects
     objects = sorted(objects, key=lodKey)
 
     # Make sure the object is in OBJECT mode, otherwise some of the functions might fail
-    bpy.ops.object.mode_set(mode='OBJECT')
+    if (bpy.context.object.mode!='OBJECT'):
+        bpy.ops.object.mode_set(mode='OBJECT')
     
     # Write file header
     writeSignature(filePtr, 'MLOD')


### PR DESCRIPTION
Check if it's in edit mode before actually trying to force object mode, as linked objects are already in object mode, and can't have their mode changed.

Having the ability to use linked objects is a literal exponential timesave for some of my projects, due to how many slightly-different p3ds I need for vehicle variants.