### PR TITLE
Component merge

### DIFF
--- a/ArmaToolbox/MDLexporter.py
+++ b/ArmaToolbox/MDLexporter.py
@@ -643,6 +643,9 @@ def exportObjectListAsMDL(myself, filePtr, applyModifiers, mergeSameLOD, objects
                 newTmpObj.select_set(True)
                 bpy.context.view_layer.objects.active = newTmpObj
                 ArmaTools.joinObjectToObject(bpy.context)      
+                arma = newTmpObj.armaObjProps
+                if arma.isArmaObject and (arma.lod == '1.000e+13' or arma.lod == '4.000e+13' or arma.lod == '7.000e+15'):
+                    ArmaTools.createComponents(bpy.context)
                 export_lod(filePtr, newTmpObj, wm, realIndex)
 
                 # Make sure we only have this one selected and delete it

--- a/ArmaToolbox/MDLexporter.py
+++ b/ArmaToolbox/MDLexporter.py
@@ -644,7 +644,7 @@ def exportObjectListAsMDL(myself, filePtr, applyModifiers, mergeSameLOD, objects
                 bpy.context.view_layer.objects.active = newTmpObj
                 ArmaTools.joinObjectToObject(bpy.context)      
                 arma = newTmpObj.armaObjProps
-                if arma.isArmaObject and (arma.lod == '1.000e+13' or arma.lod == '4.000e+13' or arma.lod == '7.000e+15'):
+                if arma.isArmaObject and (arma.lod == '1.000e+13' or arma.lod == '4.000e+13' or arma.lod == '7.000e+15' or arma.lod == '6.000e+15'):
                     ArmaTools.createComponents(bpy.context)
                 export_lod(filePtr, newTmpObj, wm, realIndex)
 

--- a/ArmaToolbox/__init__.py
+++ b/ArmaToolbox/__init__.py
@@ -134,7 +134,7 @@ def vgroupExtra(self, context):
             row = layout.row()
             row.label(text = "ARMA group weight {:6.2f}".format(getMassForSelection(obj, obj.vertex_groups[actGrp].name)))
 
-    if arma.isArmaObject and (arma.lod == '1.000e+13' or arma.lod == '4.000e+13' or arma.lod == '7.000e+15'):
+    if arma.isArmaObject and (arma.lod == '1.000e+13' or arma.lod == '4.000e+13' or arma.lod == '7.000e+15' or arma.lod == '6.000e+15'):
         row = layout.row()
         row.operator("armatoolbox.create_components")
             # TODO:


### PR DESCRIPTION
Adds automatic componentXX generation when exporting an LOD that uses them, if the LOD was generated by merging objects together. This way, the LOD won't have reused component names if you mix and match different objects in different models.

Also adds View Geometry as a valid LOD for componentXX generation, both for the panel button, and in the export behavior.