### PR TITLE
Added: Support for the x64 Linux platform.

### DIFF
--- a/ArmaToolbox/blender_manifest.toml
+++ b/ArmaToolbox/blender_manifest.toml
@@ -17,7 +17,7 @@ license = [
   "SPDX:GPL-2.0-or-later",
 ]
 
-platforms = ["windows-amd64", "windows-x64"]
+platforms = ["windows-amd64", "windows-x64", "linux-x64"]
 
 [permissions]
 files = "Import/export from/to disk, run post processor binary"


### PR DESCRIPTION
Enable support for the Linux platform. I've been using and testing your extension on Ubuntu 22.04 for over 8 months and haven't had any critical problems so far.